### PR TITLE
Add getter for m_pBRDF_LUT_SRV

### DIFF
--- a/GLTF_PBR_Renderer/interface/GLTF_PBR_Renderer.hpp
+++ b/GLTF_PBR_Renderer/interface/GLTF_PBR_Renderer.hpp
@@ -225,6 +225,7 @@ public:
     // clang-format off
     ITextureView* GetIrradianceCubeSRV()    { return m_pIrradianceCubeSRV; }
     ITextureView* GetPrefilteredEnvMapSRV() { return m_pPrefilteredEnvMapSRV; }
+    ITextureView* GetBRDFLUTSRV()           { return m_pBRDF_LUT_SRV; }
     ITextureView* GetWhiteTexSRV()          { return m_pWhiteTexSRV; }
     ITextureView* GetBlackTexSRV()          { return m_pBlackTexSRV; }
     ITextureView* GetDefaultNormalMapSRV()  { return m_pDefaultNormalMapSRV; }


### PR DESCRIPTION
We're currently in the process of integrating the PBR rendering of the Diligent GLTF PBR Viewer sample into our rendering application, but we have our own gltf-loading and material/PSO management system in place. We are using the GLTF_PBR_Renderer mostly for cubemap and BRDF LUT computation and this little change would make our lifes a lot easier. 