### PR TITLE
SSR: made depth-buffer thickness independent of scene scale (close #39)

### DIFF
--- a/Hydrogent/src/Tasks/HnPostProcessTask.cpp
+++ b/Hydrogent/src/Tasks/HnPostProcessTask.cpp
@@ -461,9 +461,9 @@ void HnPostProcessTask::Execute(pxr::HdTaskContext* TaskCtx)
         m_PostFXContext->Execute(PostFXAttribs);
 
         HLSL::ScreenSpaceReflectionAttribs SSRAttribs{};
-        SSRAttribs.RoughnessChannel      = 0;
-        SSRAttribs.DepthBufferThickness  = 0.015f * 10.0f;
-        SSRAttribs.IsRoughnessPerceptual = true;
+        SSRAttribs.MaxTraversalIntersections = 64;
+        SSRAttribs.RoughnessChannel          = 0;
+        SSRAttribs.IsRoughnessPerceptual     = true;
 
         ScreenSpaceReflection::RenderAttributes SSRRenderAttribs{};
         SSRRenderAttribs.pDevice            = pDevice;

--- a/PostProcess/ScreenSpaceReflection/src/ScreenSpaceReflection.cpp
+++ b/PostProcess/ScreenSpaceReflection/src/ScreenSpaceReflection.cpp
@@ -352,7 +352,7 @@ void ScreenSpaceReflection::UpdateUI(HLSL::ScreenSpaceReflectionAttribs& SSRAttr
     if (m_ImGuiDisplayMode == 0)
     {
         ImGui::SliderFloat("Roughness Threshold", &SSRAttribs.RoughnessThreshold, 0.0f, 1.0f);
-        ImGui::SliderFloat("Depth Buffer Thickness", &SSRAttribs.DepthBufferThickness, 0.0f, 1.0f);
+        ImGui::SliderFloat("Depth Buffer Thickness", &SSRAttribs.DepthBufferThickness, 0.0f, 1.0f, "%.3f", ImGuiSliderFlags_Logarithmic);
         ImGui::SliderFloat("Temporal Stability Radiance Factor", &SSRAttribs.TemporalRadianceStabilityFactor, 0.0f, 1.0f);
         ImGui::SliderInt("Max Traversal Iterations", reinterpret_cast<Int32*>(&SSRAttribs.MaxTraversalIntersections), 0, 256);
     }

--- a/Shaders/PostProcess/ScreenSpaceReflection/private/ComputeIntersection.fx
+++ b/Shaders/PostProcess/ScreenSpaceReflection/private/ComputeIntersection.fx
@@ -230,9 +230,9 @@ float ValidateHit(float3 Hit, float2 ScreenCoordUV, float3 RayDirectionWS, float
     float Vignette = CalculateEdgeVignette(Hit.xy, ScreenSize);
 #endif
 
-    // We accept all hits that are within a reasonable minimum distance below the surface.
-    // Add constant in linear space to avoid growing of the reflections toward the reflected objects.
-    float Confidence = 1.0f - smoothstep(0.0f, DepthBufferThickness, Distance);
+    // We accept all hits that are within a reasonable minimum screen-space distance below the surface.
+    // Add constant in linear space to avoid growing of the reflections towards the reflected objects.
+    float Confidence = 1.0f - smoothstep(0.0f, DepthBufferThickness, Distance / (SurfaceVS.z + FLT_EPS));
     Confidence *= Confidence;
 
     return Vignette * Confidence;

--- a/Shaders/PostProcess/ScreenSpaceReflection/public/ScreenSpaceReflectionStructures.fxh
+++ b/Shaders/PostProcess/ScreenSpaceReflection/public/ScreenSpaceReflectionStructures.fxh
@@ -62,7 +62,7 @@
 
 struct ScreenSpaceReflectionAttribs
 {
-    float DepthBufferThickness               DEFAULT_VALUE(0.015f);
+    float DepthBufferThickness               DEFAULT_VALUE(0.025f);
     float RoughnessThreshold                 DEFAULT_VALUE(0.2f);
     uint  MostDetailedMip                    DEFAULT_VALUE(0);
     uint  Padding0                           DEFAULT_VALUE(0);


### PR DESCRIPTION
This change seems to solve the problem of making the parameter independent of the scene scale. In particular, the dodge pickup scene now works fine with scales 0.01 and 10. Also, Tutorial 27 works with the default value as well.
The 0.025 value seems to provide best results.

It may be worth renaming the `DepthBufferThickness` parameter to make its purpose more clear.

@MikhailGorobets please test that it works fine for you.