### PR TITLE
Build fixes for Rocky 8/9 (VFX Platform 2023+)

### DIFF
--- a/Hydrogent/CMakeLists.txt
+++ b/Hydrogent/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required (VERSION 3.13)
 
 project(Diligent-Hydrogent CXX)
 
+# We need to bring in the OpenUSD package explicitly so that USDViewer can
+# link with the right version of python and boost::python
+if(PLATFORM_LINUX)
+    set(pxr_DIR ${DILIGENT_USD_PATH})
+    find_package(pxr)
+endif()
+
 set(SOURCE
     src/HnMaterial.cpp
     src/HnMaterialNetwork.cpp

--- a/Hydrogent/src/HnRenderDelegate.cpp
+++ b/Hydrogent/src/HnRenderDelegate.cpp
@@ -171,7 +171,7 @@ static std::shared_ptr<USD_Renderer> CreateUSDRenderer(const HnRenderDelegate::C
     }
     else
     {
-        VERIFY(RenderDelegateCI.TextureBindingMode == HN_MATERIAL_TEXTURES_BINDING_MODE_LEGACY);
+        VERIFY_EXPR(RenderDelegateCI.TextureBindingMode == HN_MATERIAL_TEXTURES_BINDING_MODE_LEGACY);
         USDRendererCI.ShaderTexturesArrayMode = USD_Renderer::SHADER_TEXTURE_ARRAY_MODE_NONE;
     }
 

--- a/Hydrogent/src/HnRenderDelegate.cpp
+++ b/Hydrogent/src/HnRenderDelegate.cpp
@@ -263,7 +263,7 @@ HnRenderDelegate::HnRenderDelegate(const CreateInfo& CI) :
     m_PrimitiveAttribsCB{CreatePrimitiveAttribsCB(CI.pDevice)},
     m_MaterialSRBCache{HnMaterial::CreateSRBCache()},
     m_USDRenderer{CreateUSDRenderer(CI, m_PrimitiveAttribsCB, m_MaterialSRBCache)},
-    m_TextureRegistry{CI.pDevice, CI.TextureAtlasDim != 0 ? m_ResourceMgr : nullptr},
+    m_TextureRegistry{CI.pDevice, CI.TextureAtlasDim != 0 ? m_ResourceMgr : RefCntAutoPtr<GLTF::ResourceManager>{}},
     m_RenderParam{std::make_unique<HnRenderParam>(CI.UseVertexPool, CI.UseIndexPool, CI.TextureBindingMode)}
 {
 }


### PR DESCRIPTION
Hi all, this was a relatively pleasant build process except for a few things:

I added a `find_package(pxr)` with `pxr_DIR` set to `DILIGENT_USD_PATH` so that it also brings in the python and boost python libraries to link against for USDViewer.

The other 'fix' I am not sure if it is valid, but I was getting
```
error: operands to ‘?:’ have different types ‘Diligent::RefCntAutoPtr<Diligent::GLTF::ResourceManager>’ and ‘std::nullptr_t’
```
Under GCC 11.4.1 that comes with Rocky 9.3.

Cheers