### PR TITLE
Depth bias

### DIFF
--- a/Shaders/PBR/public/PBR_Shading.fxh
+++ b/Shaders/PBR/public/PBR_Shading.fxh
@@ -647,7 +647,7 @@ void ApplyPunctualLight(in    SurfaceShadingInfo     Shading,
         float4 ShadowPos = mul(float4(Shading.Pos, 1.0), ShadowMapInfo.WorldToLightProjSpace);
         ShadowPos.xy /= ShadowPos.w;
         ShadowPos.xy = NormalizedDeviceXYToTexUV(ShadowPos.xy) * ShadowMapInfo.UVScale + ShadowMapInfo.UVBias;
-        ShadowPos.z  = NormalizedDeviceZToDepth(ShadowPos.z);
+        ShadowPos.z  = NormalizedDeviceZToDepth(ShadowPos.z) - ShadowMapInfo.FixedDepthBias;
         float4 ShadowMapSize;
         float Elems;
         ShadowMap.GetDimensions(ShadowMapSize.x, ShadowMapSize.y, Elems);

--- a/Shaders/PBR/public/PBR_Structures.fxh
+++ b/Shaders/PBR/public/PBR_Structures.fxh
@@ -277,7 +277,7 @@ struct PBRShadowMapInfo
     float2 UVBias;
     
     float    ShadowMapSlice;
-    float    Padding0;
+    float    FixedDepthBias;
     float    Padding1;
     float    Padding2;
 };


### PR DESCRIPTION
I'm not sure how you don't have shadow acne in the Hydrogent shadows but any shadow integration with the Diligent PBR has acne due to no bias at all being applied. Seems to be an easy fix just to get a fixed bias going.