### PR TITLE
Add scaled normal and sample it properly

### DIFF
--- a/Shaders/PBR/private/PBR_Textures.fxh
+++ b/Shaders/PBR/private/PBR_Textures.fxh
@@ -472,6 +472,8 @@ float3 SampleNormalTexture(PBRMaterialTextureAttribs TexAttribs,
 #endif
     }
 
+    SampledNormal = normalize(SampledNormal * 2.0 - 1.0) * float3(TexAttribs.NormalScale, TexAttribs.NormalScale, 1.0);
+    SampledNormal = (SampledNormal + 1.0) / 2.0;
     return SampledNormal;
 }
 

--- a/Shaders/PBR/private/PBR_Textures.fxh
+++ b/Shaders/PBR/private/PBR_Textures.fxh
@@ -471,10 +471,8 @@ float3 SampleNormalTexture(PBRMaterialTextureAttribs TexAttribs,
         }
 #endif
     }
-
-    SampledNormal = normalize(SampledNormal * 2.0 - 1.0) * float3(TexAttribs.NormalScale, TexAttribs.NormalScale, 1.0);
-    SampledNormal = (SampledNormal + 1.0) / 2.0;
-    return float3(SampledNormal.rg, 1.0);
+    
+    return normalize(SampledNormal * 2.0 - 1.0) * float3(TexAttribs.NormalScale, TexAttribs.NormalScale, 1.0);
 }
 
 float3 GetMicroNormal(PBRMaterialShaderInfo Material,
@@ -484,7 +482,7 @@ float3 GetMicroNormal(PBRMaterialShaderInfo Material,
                       float2                dNormalMapUV_dy,
                       float                 MipBias)
 {
-    float3 MicroNormal = float3(0.5, 0.5, 1.0);
+    float3 MicroNormal = float3(0.0, 0.0, 1.0);
 
 #   if USE_NORMAL_MAP && (USE_TEXCOORD0 || USE_TEXCOORD1)
     {
@@ -499,7 +497,7 @@ float3 GetMicroNormal(PBRMaterialShaderInfo Material,
     }
 #endif
 
-    return MicroNormal * float3(2.0, 2.0, 2.0) - float3(1.0, 1.0, 1.0);
+    return MicroNormal;
 }
 
 float GetOcclusion(VSOutput              VSOut,
@@ -650,7 +648,7 @@ float3 GetClearcoatNormal(PBRMaterialShaderInfo Material,
                           float2                dNormalMapUV_dy,
                           float                 MipBias)
 {
-    float3 ClearcoatNormal = float3(0.5, 0.5, 1.0);
+    float3 ClearcoatNormal = float3(0.0, 0.0, 1.0);
 #   if ENABLE_CLEAR_COAT
     {
 #       if USE_CLEAR_COAT_NORMAL_MAP
@@ -668,7 +666,7 @@ float3 GetClearcoatNormal(PBRMaterialShaderInfo Material,
 #       endif
     }
 #endif
-    return ClearcoatNormal * float3(2.0, 2.0, 2.0) - float3(1.0, 1.0, 1.0);
+    return ClearcoatNormal;
 }
 
 

--- a/Shaders/PBR/private/PBR_Textures.fxh
+++ b/Shaders/PBR/private/PBR_Textures.fxh
@@ -474,7 +474,7 @@ float3 SampleNormalTexture(PBRMaterialTextureAttribs TexAttribs,
 
     SampledNormal = normalize(SampledNormal * 2.0 - 1.0) * float3(TexAttribs.NormalScale, TexAttribs.NormalScale, 1.0);
     SampledNormal = (SampledNormal + 1.0) / 2.0;
-    return SampledNormal;
+    return float3(SampledNormal.rg, 1.0);
 }
 
 float3 GetMicroNormal(PBRMaterialShaderInfo Material,

--- a/Shaders/PBR/private/RenderPBR.psh
+++ b/Shaders/PBR/private/RenderPBR.psh
@@ -77,6 +77,8 @@ PBRMaterialTextureAttribs GetDefaultTextureAttribs()
 
     Attribs.UVScaleAndRotation  = float4(1.0, 0.0, 0.0, 1.0);
     Attribs.AtlasUVScaleAndBias = float4(1.0, 1.0, 0.0, 0.0);
+
+    Attribs.NormalScale = 1.0;
     
     return Attribs;
 }

--- a/Shaders/PBR/public/PBR_Structures.fxh
+++ b/Shaders/PBR/public/PBR_Structures.fxh
@@ -205,6 +205,11 @@ struct PBRMaterialTextureAttribs
 
     float4 UVScaleAndRotation;
     float4 AtlasUVScaleAndBias;
+
+    float NormalScale;
+    float Padding0;
+    float Padding1;
+    float Padding2;
 };
 #ifdef CHECK_STRUCT_ALIGNMENT
 	CHECK_STRUCT_ALIGNMENT(PBRMaterialTextureAttribs);


### PR DESCRIPTION
Not sure why normal scale was left out GTLFLoader and the PBR.

https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-material-normaltextureinfo

```
5.20.3. material.normalTextureInfo.scale
The scalar parameter applied to each normal vector of the texture. This value scales the normal vector in X and Y directions using the formula: scaledNormal = normalize<sampled normal texture value> * 2.0 - 1.0) * vec3(<normal scale>, <normal scale>, 1.0.
 
Type: number
Required: No, default: 1

```
This adds the necessary scale factor to normals, for both normal maps and clear coat normals.

Paired with: https://github.com/DiligentGraphics/DiligentTools/pull/235