### PR TITLE
PBR Renderer: add prevent shadow flag from getting filtered out

### DIFF
--- a/PBR/src/GLTF_PBR_Renderer.cpp
+++ b/PBR/src/GLTF_PBR_Renderer.cpp
@@ -562,7 +562,8 @@ void GLTF_PBR_Renderer::Render(IDeviceContext*              pCtx,
                 PSO_FLAG_CONVERT_OUTPUT_TO_SRGB |
                 PSO_FLAG_ENABLE_TONE_MAPPING |
                 PSO_FLAG_COMPUTE_MOTION_VECTORS |
-                PSO_FLAG_USE_LIGHTS;
+                PSO_FLAG_USE_LIGHTS |
+                PSO_FLAG_ENABLE_SHADOWS;
             if (m_Settings.EnableIBL)
             {
                 PSOFlags |= PSO_FLAG_USE_IBL;


### PR DESCRIPTION
Seemed necessary for the GLTF PBR renderer for the shadow flag to stay on.