### PR TITLE
Gltf bug fix

### DIFF
--- a/PBR/src/GLTF_PBR_Renderer.cpp
+++ b/PBR/src/GLTF_PBR_Renderer.cpp
@@ -774,7 +774,8 @@ void GLTF_PBR_Renderer::Render(IDeviceContext*              pCtx,
             else
             {
                 DrawAttribs drawAttrs{primitive.VertexCount, DRAW_FLAG_VERIFY_ALL};
-                drawAttrs.StartVertexLocation = BaseVertex;
+                //drawAttrs.StartVertexLocation = BaseVertex;
+                drawAttrs.StartVertexLocation = BaseVertex + primitive.VertexStart;
                 pCtx->Draw(drawAttrs);
             }
         }

--- a/PBR/src/GLTF_PBR_Renderer.cpp
+++ b/PBR/src/GLTF_PBR_Renderer.cpp
@@ -774,7 +774,7 @@ void GLTF_PBR_Renderer::Render(IDeviceContext*              pCtx,
             else
             {
                 DrawAttribs drawAttrs{primitive.VertexCount, DRAW_FLAG_VERIFY_ALL};
-                drawAttrs.StartVertexLocation = BaseVertex + primitive.VertexStart;
+                drawAttrs.StartVertexLocation = BaseVertex + primitive.FirstVertex;
                 pCtx->Draw(drawAttrs);
             }
         }

--- a/PBR/src/GLTF_PBR_Renderer.cpp
+++ b/PBR/src/GLTF_PBR_Renderer.cpp
@@ -774,7 +774,6 @@ void GLTF_PBR_Renderer::Render(IDeviceContext*              pCtx,
             else
             {
                 DrawAttribs drawAttrs{primitive.VertexCount, DRAW_FLAG_VERIFY_ALL};
-                //drawAttrs.StartVertexLocation = BaseVertex;
                 drawAttrs.StartVertexLocation = BaseVertex + primitive.VertexStart;
                 pCtx->Draw(drawAttrs);
             }


### PR DESCRIPTION
GLTF Renderer: use primitive start vertex for non-indexed primitives